### PR TITLE
Add mobile/small-screen responsive layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Splunk Toolkit are documented here, newest first.
 
 ---
 
+## 2026-05-31
+
+### Added
+
+- **Mobile / small-screen layout** — on viewports narrower than `768px` the desktop side-by-side resizable split (which collapsed each column to an unusable width on a phone, causing the Raw panel header, placeholder, footer and metadata to overlap) is replaced by a single-panel-at-a-time view. A new segmented control switches between **Raw**, **props.conf**, **transforms.conf** and **Output**, with each panel getting the full main area. New `useMediaQuery` hook ([src/hooks/useMediaQuery.ts](src/hooks/useMediaQuery.ts)) and `MobileShell` component ([src/components/layout/MobileShell.tsx](src/components/layout/MobileShell.tsx)).
+
+### Fixed
+
+- **Output tab bar clipped on small laptop screens** — `Tabs` tablist is now horizontally scrollable (`overflow-x-auto`, `min-w-0`) with non-shrinking, non-wrapping tab buttons (`shrink-0 whitespace-nowrap`), so the Preview/CIM Models/Fields/Pipeline/Architecture tabs no longer wrap or get cut off in narrow output panels.
+- **Header crowding on narrow screens** — the "Commands" label and `⌘K` kbd hint collapse to just the search icon below the `sm` breakpoint.
+
+---
+
 ## 2026-04-21
 
 ### Fixed

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -11,8 +11,10 @@ import { SettingsPanel } from '../settings/SettingsPanel';
 import { FirstRunBanner } from '../onboarding/FirstRunBanner';
 import { useProcessingPipeline } from '../../hooks/useProcessingPipeline';
 import { useAppStore } from '../../store/useAppStore';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { CommandPalette } from '../ui/CommandPalette';
 import { ScaffoldModal } from '../scaffold/ScaffoldModal';
+import { MobileShell } from './MobileShell';
 
 function ResizeHandle({ direction = 'vertical' }: { direction?: 'horizontal' | 'vertical' }) {
   return (
@@ -39,6 +41,7 @@ export function AppShell() {
   const propsCollapsed = useAppStore((s) => !!s.collapsedPanels['props.conf']);
   const transformsCollapsed = useAppStore((s) => !!s.collapsedPanels['transforms.conf']);
   const scaffoldOpen = useAppStore((s) => s.scaffoldOpen);
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   // Build the resizable panel group key based on which panels are expanded
   // This forces a clean re-mount when collapse state changes
@@ -53,6 +56,9 @@ export function AppShell() {
       <CommandPalette />
       {scaffoldOpen && <ScaffoldModal />}
       <main id="main-content" className="flex-1 min-h-0">
+        {isMobile ? (
+          <MobileShell />
+        ) : (
         <Group orientation="horizontal" id="main-horizontal">
           {/* Left side: Raw, Props, Transforms */}
           <Panel defaultSize={38} minSize={20} id="left-inputs">
@@ -110,6 +116,7 @@ export function AppShell() {
             </ErrorBoundary>
           </Panel>
         </Group>
+        )}
       </main>
       <StatusBar />
     </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -60,8 +60,8 @@ export function Header() {
                 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
             >
               <Icon name="search" className="w-3.5 h-3.5" />
-              <span>Commands</span>
-              <kbd className="ml-1 px-1 rounded text-[10px] font-mono bg-[var(--color-bg-tertiary)]">⌘K</kbd>
+              <span className="hidden sm:inline">Commands</span>
+              <kbd className="ml-1 px-1 rounded text-[10px] font-mono bg-[var(--color-bg-tertiary)] hidden sm:inline">⌘K</kbd>
             </button>
           </Tooltip>
           {hasAnyContent && (

--- a/src/components/layout/MobileShell.tsx
+++ b/src/components/layout/MobileShell.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { RawPanel } from '../raw/RawPanel';
+import { PropsConfEditor } from '../editor/PropsConfEditor';
+import { TransformsConfEditor } from '../editor/TransformsConfEditor';
+import { PreviewPanel } from '../preview/PreviewPanel';
+import { ErrorBoundary } from '../ui/ErrorBoundary';
+import { Icon } from '../ui/Icon';
+import type { IconName } from '../ui/Icon';
+
+type MobileView = 'raw' | 'props' | 'transforms' | 'output';
+
+const VIEWS: { id: MobileView; label: string; icon: IconName }[] = [
+  { id: 'raw', label: 'Raw', icon: 'document' },
+  { id: 'props', label: 'props', icon: 'settings' },
+  { id: 'transforms', label: 'transforms', icon: 'refresh' },
+  { id: 'output', label: 'Output', icon: 'eye' },
+];
+
+/**
+ * Single-panel-at-a-time layout for narrow viewports. The desktop resizable
+ * split collapses every column to an unusable width on a phone, so on mobile we
+ * show one full-width panel and switch between them with a segmented control.
+ */
+export function MobileShell() {
+  const [view, setView] = useState<MobileView>('raw');
+
+  return (
+    <div className="h-full flex flex-col">
+      <div
+        role="tablist"
+        aria-label="Workspace panels"
+        className="shrink-0 flex items-stretch border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] overflow-x-auto"
+      >
+        {VIEWS.map((v) => {
+          const isActive = v.id === view;
+          return (
+            <button
+              key={v.id}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setView(v.id)}
+              className={[
+                'flex-1 min-w-0 flex flex-col items-center justify-center gap-0.5 px-2 py-1.5',
+                'text-[11px] font-medium cursor-pointer border-b-2 -mb-px outline-none focus-visible:ring-2 transition-colors',
+                isActive
+                  ? 'text-[var(--color-accent)] border-b-[var(--color-accent)]'
+                  : 'text-[var(--color-text-muted)] border-b-transparent hover:text-[var(--color-text-secondary)]',
+              ].join(' ')}
+            >
+              <Icon name={v.icon} className="w-4 h-4 shrink-0" />
+              <span className="truncate max-w-full">{v.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex-1 min-h-0">
+        {view === 'raw' && (
+          <ErrorBoundary panelName="Raw Data">
+            <RawPanel />
+          </ErrorBoundary>
+        )}
+        {view === 'props' && (
+          <ErrorBoundary panelName="props.conf Editor">
+            <PropsConfEditor />
+          </ErrorBoundary>
+        )}
+        {view === 'transforms' && (
+          <ErrorBoundary panelName="transforms.conf Editor">
+            <TransformsConfEditor />
+          </ErrorBoundary>
+        )}
+        {view === 'output' && (
+          <ErrorBoundary panelName="Output">
+            <PreviewPanel />
+          </ErrorBoundary>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/preview/PreviewPanel.tsx
+++ b/src/components/preview/PreviewPanel.tsx
@@ -61,7 +61,7 @@ export function PreviewPanel() {
   return (
     <div className="h-full flex flex-col bg-[var(--color-bg-primary)]">
       <div className="flex items-center justify-between border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-secondary)]">
-        <div className="flex items-center gap-2 px-3">
+        <div className="flex items-center gap-2 px-3 shrink-0">
           <Icon name="eye" className="w-3.5 h-3.5 text-[var(--color-accent)]" />
           <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">Output</span>
         </div>

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-type IconName =
+export type IconName =
   | 'chevron-down'
   | 'chevron-left'
   | 'chevron-right'

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -51,20 +51,20 @@ export function Tabs({ tabs, activeTab, onTabChange, ariaLabel, size = 'md', var
       ref={tablistRef}
       role="tablist"
       aria-label={ariaLabel}
-      className={variant === 'secondary' ? 'flex gap-0.5 p-1' : 'flex gap-1'}
+      className={variant === 'secondary' ? 'flex gap-0.5 p-1 overflow-x-auto min-w-0' : 'flex gap-1 overflow-x-auto min-w-0'}
       onKeyDown={handleKeyDown}
     >
       {tabs.map((tab) => {
         const isActive = tab.id === activeTab;
         const underlineClasses = [
-          'relative flex items-center gap-1.5 font-medium cursor-pointer outline-none focus-visible:ring-2 border-b-2 -mb-px',
+          'relative flex items-center gap-1.5 font-medium cursor-pointer outline-none focus-visible:ring-2 border-b-2 -mb-px shrink-0 whitespace-nowrap',
           size === 'sm' ? 'px-2.5 py-1.5 text-xs' : 'px-3 py-1.5 text-sm',
           isActive
             ? 'text-[var(--color-accent)] border-b-[var(--color-accent)]'
             : 'text-[var(--color-text-muted)] border-b-transparent hover:text-[var(--color-text-secondary)]',
         ].join(' ');
         const secondaryClasses = [
-          'relative flex items-center gap-1.5 font-medium cursor-pointer outline-none focus-visible:ring-1 rounded transition-colors',
+          'relative flex items-center gap-1.5 font-medium cursor-pointer outline-none focus-visible:ring-1 rounded transition-colors shrink-0 whitespace-nowrap',
           size === 'sm' ? 'px-2.5 py-1 text-xs' : 'px-3 py-1.5 text-sm',
           isActive
             ? 'bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border)] shadow-sm'

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Subscribe to a CSS media query and re-render when its match state changes.
+ * Returns false during server-side rendering (no `window`).
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = (callback: () => void) => {
+    if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+    const mql = window.matchMedia(query);
+    mql.addEventListener('change', callback);
+    return () => mql.removeEventListener('change', callback);
+  };
+
+  const getSnapshot = () =>
+    typeof window !== 'undefined' && !!window.matchMedia && window.matchMedia(query).matches;
+
+  const getServerSnapshot = () => false;
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
On viewports under 768px, replace the desktop side-by-side resizable
split (which collapsed each column to an unusable width and caused the
Raw panel chrome to overlap) with a single-panel-at-a-time view: a
segmented control switches between Raw, props.conf, transforms.conf and
Output, each getting the full main area.

Also make the Output tab bar horizontally scrollable so tabs no longer
clip on small laptops, and collapse the header Commands button to an
icon on narrow screens.

https://claude.ai/code/session_01Qx94uC2RYpugiSKiJNhsJd