### PR TITLE
Fix misleading JSON extraction + add data/config validation

### DIFF
--- a/src/components/editor/EditorValidationList.tsx
+++ b/src/components/editor/EditorValidationList.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
 import { useAppStore } from '../../store/useAppStore';
-import type { ValidationDiagnostic } from '../../engine/types';
+import type { ValidationDiagnostic, DiagnosticTarget } from '../../engine/types';
 import { Icon } from '../ui/Icon';
 import { getEditor } from './editorRegistry';
 
 interface EditorValidationListProps {
-  file: 'props.conf' | 'transforms.conf';
+  file: DiagnosticTarget;
 }
 
 export function EditorValidationList({ file }: EditorValidationListProps) {

--- a/src/components/preview/tabs/shared/__tests__/fieldTreeUtils.test.ts
+++ b/src/components/preview/tabs/shared/__tests__/fieldTreeUtils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildFieldTree, type FieldNode } from '../fieldTreeUtils';
+
+/** Build the colour map from a list of field names (colours are irrelevant to structure). */
+function colorMap(names: string[]): Map<string, string> {
+  return new Map(names.map((n, i) => [n, `#00000${i % 10}`]));
+}
+
+/** Collapse a tree to `name(child,child)` strings for concise structural assertions. */
+function shape(nodes: FieldNode[]): string[] {
+  return nodes.map((n) =>
+    n.children.length ? `${n.name}(${shape(n.children).join(',')})` : n.name,
+  );
+}
+
+describe('buildFieldTree', () => {
+  it('nests JSON-flattened leaves under synthesized container nodes', () => {
+    // Mirrors AWS Network Firewall extraction: only leaf fields exist; `event` and
+    // `event.alert` are never extracted as fields, yet must appear as group headers.
+    const fields = [
+      'availability_zone',
+      'event.alert.action',
+      'event.alert.category',
+      'event.app_proto',
+      'event.verdict.action',
+      'firewall_name',
+    ];
+    const roots = buildFieldTree(colorMap(fields), new Set(), new Map());
+
+    expect(shape(roots)).toEqual([
+      'availability_zone',
+      'event(event.alert(event.alert.action,event.alert.category),event.app_proto,event.verdict(event.verdict.action))',
+      'firewall_name',
+    ]);
+  });
+
+  it('marks synthesized parents as containers and keeps real depth', () => {
+    const roots = buildFieldTree(colorMap(['event.alert.action']), new Set(), new Map());
+    const event = roots[0];
+    expect(event.name).toBe('event');
+    expect(event.isContainer).toBe(true);
+    expect(event.depth).toBe(0);
+    const alert = event.children[0];
+    expect(alert.name).toBe('event.alert');
+    expect(alert.isContainer).toBe(true);
+    expect(alert.depth).toBe(1);
+    const action = alert.children[0];
+    expect(action.isContainer).toBe(false);
+    expect(action.depth).toBe(2);
+    expect(action.children).toHaveLength(0);
+  });
+
+  it('inherits a synthesized container colour from its first descendant leaf', () => {
+    const map = new Map<string, string>([['event.alert.action', '#abcdef']]);
+    const roots = buildFieldTree(map, new Set(), new Map());
+    expect(roots[0].color).toBe('#abcdef'); // event
+    expect(roots[0].children[0].color).toBe('#abcdef'); // event.alert
+  });
+
+  it('keeps a top-level field that is also a parent of nested fields as one node', () => {
+    // Both `a` and `a.b` extracted: `a` is a real field AND a container.
+    const roots = buildFieldTree(colorMap(['a', 'a.b']), new Set(['a']), new Map());
+    expect(roots).toHaveLength(1);
+    expect(roots[0].name).toBe('a');
+    expect(roots[0].color).toBe('#000000'); // real colour, not the synthetic placeholder
+    expect(shape(roots)).toEqual(['a(a.b)']);
+  });
+});

--- a/src/components/preview/tabs/shared/fieldTreeUtils.ts
+++ b/src/components/preview/tabs/shared/fieldTreeUtils.ts
@@ -8,6 +8,10 @@ export interface FieldNode {
   children: FieldNode[];
 }
 
+// Placeholder colour for synthesized container nodes; replaced in a final pass with
+// the colour of the container's first descendant leaf (see resolveContainerColor).
+const SYNTHETIC_CONTAINER_COLOR = '#94a3b8';
+
 export function buildFieldTree(
   fieldColorMap: Map<string, string>,
   containerFields: Set<string>,
@@ -15,28 +19,76 @@ export function buildFieldTree(
 ): FieldNode[] {
   const roots: FieldNode[] = [];
   const nodeMap = new Map<string, FieldNode>();
+  // Paths we created as intermediate containers rather than as real extracted
+  // fields. Splunk's JSON flattening only emits leaf fields, so the parent objects
+  // (`event`, `event.alert`, …) never exist as fields of their own — without
+  // synthesizing them, nested fields collapse into depth-indented roots that
+  // visually nest under whatever unrelated root happens to precede them.
+  const synthesized = new Set<string>();
+
+  // Link a node under its parent, creating any missing ancestor containers.
+  function link(node: FieldNode, parts: string[]): void {
+    if (parts.length > 1) {
+      ensureContainer(parts.slice(0, -1).join('.')).children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function ensureContainer(path: string): FieldNode {
+    const existing = nodeMap.get(path);
+    if (existing) return existing;
+    const parts = path.split('.');
+    const node: FieldNode = {
+      name: path,
+      leafName: parts[parts.length - 1],
+      color: SYNTHETIC_CONTAINER_COLOR,
+      processor: fieldProcessorMap.get(path) ?? null,
+      isContainer: true,
+      depth: parts.length - 1,
+      children: [],
+    };
+    nodeMap.set(path, node);
+    synthesized.add(path);
+    link(node, parts);
+    return node;
+  }
 
   for (const name of Array.from(fieldColorMap.keys()).sort()) {
-    const color = fieldColorMap.get(name)!;
     const parts = name.split('.');
+    const existing = nodeMap.get(name);
+    if (existing) {
+      // This path was already synthesized as a container but is ALSO a real
+      // extracted field (e.g. both `a.b` and `a.b.c` were extracted). Promote it
+      // to a real node: adopt its true colour/processor and keep its children.
+      existing.color = fieldColorMap.get(name)!;
+      existing.processor = fieldProcessorMap.get(name) ?? existing.processor;
+      synthesized.delete(name);
+      continue;
+    }
     const node: FieldNode = {
       name,
       leafName: parts[parts.length - 1],
-      color,
+      color: fieldColorMap.get(name)!,
       processor: fieldProcessorMap.get(name) ?? null,
       isContainer: containerFields.has(name),
       depth: parts.length - 1,
       children: [],
     };
     nodeMap.set(name, node);
-
-    let placed = false;
-    for (let i = parts.length - 1; i > 0; i--) {
-      const parent = nodeMap.get(parts.slice(0, i).join('.'));
-      if (parent) { parent.children.push(node); placed = true; break; }
-    }
-    if (!placed) roots.push(node);
+    link(node, parts);
   }
+
+  // Synthesized containers have no colour of their own (they aren't extracted
+  // values), so give each one the colour of its first descendant leaf — the group
+  // header then reads as a visual set with the fields it contains.
+  const resolveContainerColor = (node: FieldNode): string => {
+    if (node.children.length === 0) return node.color;
+    const childColor = resolveContainerColor(node.children[0]);
+    if (synthesized.has(node.name)) node.color = childColor;
+    return node.color;
+  };
+  roots.forEach(resolveContainerColor);
 
   return roots;
 }

--- a/src/components/raw/RawPanel.tsx
+++ b/src/components/raw/RawPanel.tsx
@@ -1,16 +1,32 @@
-import { useMemo } from 'react';
-import Editor from '@monaco-editor/react';
+import { useMemo, useEffect, useRef } from 'react';
+import Editor, { type OnMount } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
 import { useAppStore } from '../../store/useAppStore';
 import { MetadataPanel } from '../metadata/MetadataPanel';
 import { Icon } from '../ui/Icon';
 import { ClearButton } from '../editor/ClearButton';
 import { ensureSplunkMonaco } from '../editor/splunkMonacoSetup';
+import { registerEditor, unregisterEditor } from '../editor/editorRegistry';
+import { EditorValidationList } from '../editor/EditorValidationList';
 
 export function RawPanel() {
   const rawData = useAppStore((s) => s.rawData);
   const setRawData = useAppStore((s) => s.setRawData);
   const theme = useAppStore((s) => s.theme);
   const toggleScaffold = useAppStore((s) => s.toggleScaffold);
+
+  // Register the raw-log editor so data-quality diagnostics (e.g. malformed JSON)
+  // can focus and reveal the offending input line, the same way conf editors do.
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const handleMount: OnMount = (instance) => {
+    editorRef.current = instance;
+    registerEditor('raw', instance);
+  };
+  useEffect(() => {
+    return () => {
+      if (editorRef.current) unregisterEditor('raw', editorRef.current);
+    };
+  }, []);
 
   const lineCount = useMemo(() => {
     if (!rawData) return 0;
@@ -39,6 +55,7 @@ export function RawPanel() {
           language="plaintext"
           value={rawData}
           onChange={(val) => setRawData(val ?? '')}
+          onMount={handleMount}
           beforeMount={ensureSplunkMonaco}
           theme={theme === 'dark' ? 'splunk-dark' : 'splunk-light'}
           options={{
@@ -89,6 +106,10 @@ export function RawPanel() {
           {rawData.length.toLocaleString()} chars
         </span>
         {rawData && <ClearButton onClear={() => setRawData('')} label="Clear" />}
+      </div>
+
+      <div className="flex-shrink-0">
+        <EditorValidationList file="raw" />
       </div>
 
       <div className="flex-shrink-0 border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)]">

--- a/src/engine/__tests__/confParser.test.ts
+++ b/src/engine/__tests__/confParser.test.ts
@@ -26,6 +26,33 @@ describe('parseConf — basic structure', () => {
   });
 });
 
+describe('parseConf — case-sensitive attribute names', () => {
+  it('warns when a known attribute is mis-cased (Splunk ignores it)', () => {
+    const parsed = parseConf('[aws]\nkv_mode = json', 'props.conf');
+    const warn = parsed.errors.find((e) => e.directiveKey === 'kv_mode');
+    expect(warn).toBeDefined();
+    expect(warn!.level).toBe('warning');
+    expect(warn!.message).toMatch(/case-sensitive/);
+    expect(warn!.suggestion).toBe('Change "kv_mode" to "KV_MODE".');
+    expect(warn!.line).toBe(2);
+  });
+
+  it('does not warn when the attribute is cased correctly', () => {
+    const parsed = parseConf('[aws]\nKV_MODE = json', 'props.conf');
+    expect(parsed.errors).toHaveLength(0);
+  });
+
+  it('does not warn for unknown attributes (avoids false positives)', () => {
+    const parsed = parseConf('[s]\nMY_CUSTOM_THING = 1', 'props.conf');
+    expect(parsed.errors).toHaveLength(0);
+  });
+
+  it('does not warn for class directives like EXTRACT-foo regardless of class-name case', () => {
+    const parsed = parseConf('[s]\nEXTRACT-myField = (?<a>\\d+)', 'props.conf');
+    expect(parsed.errors).toHaveLength(0);
+  });
+});
+
 describe('parseConf — line continuation (SEM-18)', () => {
   it('joins a value continued with a trailing backslash', () => {
     const text = '[s]\nLINE_BREAKER = part1\\\npart2';

--- a/src/engine/__tests__/kvMode.test.ts
+++ b/src/engine/__tests__/kvMode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { applyKvMode } from '../processors/kvMode';
-import type { SplunkEvent, ConfDirective } from '../types';
+import type { SplunkEvent, ConfDirective, ValidationDiagnostic } from '../types';
 
 function event(raw: string): SplunkEvent {
   return {
@@ -46,6 +46,54 @@ describe('applyKvMode — json', () => {
   it('extracts a top-level JSON array rather than just its first element', () => {
     const [r] = applyKvMode([event('[1,2,3]')], [dir('json')]);
     expect(r.fields['{}']).toEqual(['1', '2', '3']);
+  });
+
+  it('does NOT scavenge bare leaf fields from a nested object when the outer JSON is malformed', () => {
+    // The whole event fails JSON.parse (`<ID>` is not a valid token), but the nested
+    // `alert` object is locally well-formed. The old behaviour flattened that inner
+    // object without its path prefix, inventing bare `action`/`category` fields that
+    // Splunk never produces. It must now extract nothing and report the parse error.
+    const malformed =
+      '{"firewall_name":"fw","event":{"app_proto":"ntp",' +
+      '"alert":{"action":"blocked","signature_id":3,"rev":0,"signature":"s","category":"","severity":3},' +
+      '"flow_id":<ID>}}';
+    const diagnostics: ValidationDiagnostic[] = [];
+    const [r] = applyKvMode([event(malformed)], [dir('json')], diagnostics);
+
+    expect(r.fields['action']).toBeUndefined();
+    expect(r.fields['category']).toBeUndefined();
+    expect(r.fields['event.alert.action']).toBeUndefined();
+    expect(Object.keys(r.fields)).toHaveLength(0);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].level).toBe('warning');
+    expect(diagnostics[0].message).toMatch(/not valid JSON/);
+    // The warning is a data problem: it targets the Raw Log panel, not props.conf,
+    // and points at the offending input line.
+    expect(diagnostics[0].file).toBe('raw');
+    expect(diagnostics[0].line).toBe(1);
+  });
+
+  it('extracts the full dotted field set once the malformed JSON is valid', () => {
+    const valid =
+      '{"firewall_name":"fw","event":{"app_proto":"ntp",' +
+      '"alert":{"action":"blocked","signature_id":3},"flow_id":123}}';
+    const diagnostics: ValidationDiagnostic[] = [];
+    const [r] = applyKvMode([event(valid)], [dir('json')], diagnostics);
+
+    expect(r.fields['firewall_name']).toBe('fw');
+    expect(r.fields['event.app_proto']).toBe('ntp');
+    expect(r.fields['event.alert.action']).toBe('blocked');
+    expect(r.fields['event.flow_id']).toBe('123');
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('warns (without scavenging) when malformed JSON is seen in default auto mode', () => {
+    const diagnostics: ValidationDiagnostic[] = [];
+    const [r] = applyKvMode([event('{"a":1,"b":<ID>}')], [], diagnostics);
+    expect(Object.keys(r.fields)).toHaveLength(0);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toMatch(/KV_MODE = auto/);
   });
 });
 

--- a/src/engine/directiveRegistry.ts
+++ b/src/engine/directiveRegistry.ts
@@ -1153,6 +1153,9 @@ const DIRECTIVES: DirectiveInfo[] = [
  * we keep both entries, so the lookup helpers filter by file at runtime.
  */
 const directivesByKey = new Map<string, DirectiveInfo[]>();
+// Same directives keyed by lowercased name, for case-insensitive lookups that
+// detect case typos (Splunk attribute names are case-sensitive).
+const directivesByLowerKey = new Map<string, DirectiveInfo[]>();
 
 for (const d of DIRECTIVES) {
   const existing = directivesByKey.get(d.key);
@@ -1160,6 +1163,13 @@ for (const d of DIRECTIVES) {
     existing.push(d);
   } else {
     directivesByKey.set(d.key, [d]);
+  }
+  const lower = d.key.toLowerCase();
+  const existingLower = directivesByLowerKey.get(lower);
+  if (existingLower) {
+    existingLower.push(d);
+  } else {
+    directivesByLowerKey.set(lower, [d]);
   }
 }
 
@@ -1261,4 +1271,18 @@ export function getClassBasedDirectiveBase(
  */
 export function getAllDirectives(): DirectiveInfo[] {
   return [...DIRECTIVES];
+}
+
+/**
+ * Case-insensitive lookup → the canonical (correctly-cased) directive key, scoped
+ * to a file. Returns undefined if no known directive matches case-insensitively.
+ * Used to detect case typos: Splunk attribute names are case-sensitive, so a
+ * mis-cased name (e.g. `kv_mode`) is silently ignored and the default applies.
+ */
+export function getCanonicalDirectiveKey(
+  key: string,
+  file: 'props.conf' | 'transforms.conf',
+): string | undefined {
+  const matches = directivesByLowerKey.get(key.toLowerCase());
+  return matches?.find((d) => d.appliesTo === file || d.appliesTo === 'both')?.key;
 }

--- a/src/engine/parser/confParser.ts
+++ b/src/engine/parser/confParser.ts
@@ -12,6 +12,7 @@ import type {
   ParsedConf,
   ValidationDiagnostic,
 } from '../types';
+import { getCanonicalDirectiveKey } from '../directiveRegistry';
 
 // ---------------------------------------------------------------------------
 // Regex patterns
@@ -206,6 +207,25 @@ export function parseConf(
       const rawValue = directiveMatch[2];
 
       const { directiveType, className } = parseDirectiveKey(rawKey);
+
+      // Splunk attribute names are case-sensitive, so a mis-cased name (e.g.
+      // `kv_mode` instead of `KV_MODE`) is silently ignored — the default applies.
+      // Flag case-only mismatches (a canonical name exists but the casing differs)
+      // so the config bug surfaces. Class directives (EXTRACT-*, …) have a className
+      // and are skipped; unknown attributes return no canonical and are not flagged.
+      if (className === undefined) {
+        const canonical = getCanonicalDirectiveKey(rawKey, fileName);
+        if (canonical && canonical !== rawKey) {
+          errors.push({
+            level: 'warning',
+            message: `"${rawKey}" is ignored — attribute names are case-sensitive. Did you mean "${canonical}"?`,
+            file: fileName,
+            line: lineNumber,
+            directiveKey: rawKey,
+            suggestion: `Change "${rawKey}" to "${canonical}".`,
+          });
+        }
+      }
 
       const directive: ConfDirective = {
         key: rawKey,

--- a/src/engine/pipeline.ts
+++ b/src/engine/pipeline.ts
@@ -271,7 +271,7 @@ export function runPipeline(
       // Splunk's search-time order is EXTRACT → REPORT → automatic KV (KV_MODE) → FIELDALIAS → EVAL.
       ev = safeProcessor('EXTRACT', ev, () => extractFields(ev, evDirs, diagnostics), diagnostics);
       ev = safeProcessor('REPORT', ev, () => applyTransforms(ev, evDirs, transformsConf, 'search-time'), diagnostics, 'transforms.conf');
-      ev = safeProcessor('KV_MODE', ev, () => applyKvMode(ev, evDirs), diagnostics);
+      ev = safeProcessor('KV_MODE', ev, () => applyKvMode(ev, evDirs, diagnostics), diagnostics);
       ev = safeProcessor('FIELDALIAS', ev, () => applyFieldAliases(ev, evDirs, diagnostics), diagnostics);
       ev = safeProcessor('EVAL', ev, () => applyEvalExpressions(ev, evDirs, diagnostics), diagnostics);
       processed.push(...ev);
@@ -300,7 +300,7 @@ export function runPipeline(
     events = safeProcessor('REPORT', events, () => applyTransforms(events, directives, transformsConf, 'search-time'), diagnostics, 'transforms.conf');
 
     // Step 10: KV_MODE (automatic key-value extraction)
-    events = safeProcessor('KV_MODE', events, () => applyKvMode(events, directives), diagnostics);
+    events = safeProcessor('KV_MODE', events, () => applyKvMode(events, directives, diagnostics), diagnostics);
 
     // Step 11: FIELDALIAS
     events = safeProcessor('FIELDALIAS', events, () => applyFieldAliases(events, directives, diagnostics), diagnostics);

--- a/src/engine/processors/kvMode.ts
+++ b/src/engine/processors/kvMode.ts
@@ -1,7 +1,11 @@
-import type { SplunkEvent, ConfDirective } from '../types';
+import type { SplunkEvent, ConfDirective, ValidationDiagnostic } from '../types';
 import { flattenJson, flattenArray } from '../utils/flattenJson';
 
-export function applyKvMode(events: SplunkEvent[], directives: ConfDirective[]): SplunkEvent[] {
+export function applyKvMode(
+  events: SplunkEvent[],
+  directives: ConfDirective[],
+  diagnostics?: ValidationDiagnostic[],
+): SplunkEvent[] {
   const kvModeDir = directives.find((d) => d.key === 'KV_MODE');
   const mode = kvModeDir?.value.trim().toLowerCase() ?? 'auto';
 
@@ -12,15 +16,24 @@ export function applyKvMode(events: SplunkEvent[], directives: ConfDirective[]):
   const autoKvJsonDir = directives.find((d) => d.key === 'AUTO_KV_JSON');
   const autoKvJson = autoKvJsonDir ? autoKvJsonDir.value.trim().toLowerCase() !== 'false' : true;
 
-  return events.map((event) => {
+  // Collected across events: data that looks like JSON (starts with { or [) but
+  // fails to parse. Surfaced as a single diagnostic so a malformed paste doesn't
+  // silently yield partial/empty extractions with no explanation.
+  const parseFailures: { line: number; error: string }[] = [];
+
+  const result = events.map((event) => {
     const newFields = { ...event.fields };
     const added: string[] = [];
     let depthWarning = false;
+    let parseError: string | undefined;
 
     switch (mode) {
-      case 'json':
-        depthWarning = extractJson(event._raw, newFields, added);
+      case 'json': {
+        const r = extractJson(event._raw, newFields, added);
+        depthWarning = r.depthLimited;
+        parseError = r.parseError;
         break;
+      }
       case 'xml':
         extractXml(event._raw, newFields, added);
         break;
@@ -33,13 +46,16 @@ export function applyKvMode(events: SplunkEvent[], directives: ConfDirective[]):
         // Auto JSON extraction runs first so its leaf fields take precedence; the
         // key=value pass then fills in anything outside the JSON structure.
         if (autoKvJson) {
-          const parsed = parseWholeJson(event._raw);
-          if (parsed !== undefined) depthWarning = flattenParsed(parsed, newFields, added);
+          const whole = parseWholeJson(event._raw);
+          if (whole.kind === 'parsed') depthWarning = flattenParsed(whole.value, newFields, added);
+          else if (whole.kind === 'invalid') parseError = whole.error;
         }
         extractKeyValue(event._raw, newFields, added, mode === 'auto_escaped');
         break;
       }
     }
+
+    if (parseError) parseFailures.push({ line: event.lineNumbers.start, error: parseError });
 
     if (added.length === 0) return event;
 
@@ -57,6 +73,23 @@ export function applyKvMode(events: SplunkEvent[], directives: ConfDirective[]):
       ],
     };
   });
+
+  if (parseFailures.length > 0 && diagnostics) {
+    const first = parseFailures[0];
+    const n = parseFailures.length;
+    // This is a problem with the raw event data, not the config — surface it under
+    // the Raw Log panel and point `line` at the offending input line so the user
+    // can jump straight to it.
+    diagnostics.push({
+      level: 'warning',
+      file: 'raw',
+      line: first.line,
+      message: `KV_MODE = ${mode}: ${n} event${n === 1 ? '' : 's'} not valid JSON — JSON fields skipped (${first.error}).`,
+      suggestion: 'Check for unquoted values, trailing commas, or placeholders like <ID>.',
+    });
+  }
+
+  return result;
 }
 
 function* jsonObjectCandidates(raw: string): Generator<string> {
@@ -87,14 +120,26 @@ function* jsonObjectCandidates(raw: string): Generator<string> {
   }
 }
 
-/** Parse the whole event as JSON (object or array), or undefined if it isn't JSON. */
-function parseWholeJson(raw: string): unknown | undefined {
+/**
+ * Result of attempting to parse the whole event as JSON.
+ * - `notJson`  — the event does not begin with `{`/`[`; it was never meant to be JSON.
+ * - `invalid`  — it begins like JSON but `JSON.parse` rejected it (malformed data).
+ * - `parsed`   — a valid JSON value (object or array).
+ * Distinguishing `notJson` from `invalid` lets the caller warn about malformed JSON
+ * without spamming a diagnostic for ordinary non-JSON events.
+ */
+type WholeJsonResult =
+  | { kind: 'parsed'; value: unknown }
+  | { kind: 'notJson' }
+  | { kind: 'invalid'; error: string };
+
+function parseWholeJson(raw: string): WholeJsonResult {
   const trimmed = raw.trim();
-  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return undefined;
+  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return { kind: 'notJson' };
   try {
-    return JSON.parse(trimmed);
-  } catch {
-    return undefined;
+    return { kind: 'parsed', value: JSON.parse(trimmed) };
+  } catch (e) {
+    return { kind: 'invalid', error: e instanceof Error ? e.message : 'invalid JSON' };
   }
 }
 
@@ -107,24 +152,47 @@ function flattenParsed(parsed: unknown, fields: Record<string, string | string[]
   return false;
 }
 
-function extractJson(raw: string, fields: Record<string, string | string[]>, added: string[]): boolean {
-  // KV_MODE=json treats the event as structured JSON, so try to parse the whole
-  // event first — this also covers top-level arrays, which the embedded-object
-  // scan below would otherwise reduce to just their first element.
-  const whole = parseWholeJson(raw);
-  if (whole !== undefined) return flattenParsed(whole, fields, added);
+interface JsonExtractResult {
+  /** True if the depth limit was hit during flattening. */
+  depthLimited: boolean;
+  /** Set when the event looks like JSON but could not be parsed (for diagnostics). */
+  parseError?: string;
+}
 
-  for (const candidate of jsonObjectCandidates(raw)) {
+function extractJson(
+  raw: string,
+  fields: Record<string, string | string[]>,
+  added: string[],
+): JsonExtractResult {
+  // KV_MODE=json treats the event as structured JSON, so try to parse the whole
+  // event first — this also covers top-level arrays.
+  const whole = parseWholeJson(raw);
+  if (whole.kind === 'parsed') return { depthLimited: flattenParsed(whole.value, fields, added) };
+
+  // The whole event isn't valid JSON. Try ONLY the first/outermost embedded object.
+  // This legitimately covers JSON wrapped in surrounding text ("level=info payload={...}")
+  // or with trailing junk after a complete object.
+  //
+  // We deliberately do NOT descend into *nested* objects: recovering an inner
+  // fragment (e.g. a deeply-nested "alert" block) and flattening it without its
+  // ancestor path invents bare field names Splunk never produces (`action` instead
+  // of `event.alert.action`) and silently drops every sibling and parent field.
+  // Splunk's spath extracts nothing from JSON it cannot parse, so when the outer
+  // object is malformed we extract nothing and report the parse error instead.
+  const candidate = jsonObjectCandidates(raw).next().value;
+  if (candidate !== undefined) {
     try {
       const obj = JSON.parse(candidate);
       if (typeof obj === 'object' && obj !== null && !Array.isArray(obj)) {
-        return flattenJson(obj, fields, added);
+        return { depthLimited: flattenJson(obj, fields, added) };
       }
     } catch {
-      // Not valid JSON at this position — try next candidate
+      // The outermost embedded object is itself malformed — fall through to the
+      // diagnostic rather than scavenging a misleading inner fragment.
     }
   }
-  return false;
+
+  return { depthLimited: false, parseError: whole.kind === 'invalid' ? whole.error : undefined };
 }
 
 function addMvField(fields: Record<string, string | string[]>, added: string[], key: string, value: string): void {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -49,10 +49,18 @@ export interface ProcessingResult {
 
 export type DiagnosticLevel = 'error' | 'warning' | 'info';
 
+/**
+ * Which panel a diagnostic belongs to. `props.conf`/`transforms.conf` are config
+ * problems shown under their editors; `raw` is a data-quality problem (e.g. an
+ * event that isn't valid JSON) shown under the Raw Log panel, with `line` pointing
+ * at the offending input line rather than a config line.
+ */
+export type DiagnosticTarget = 'props.conf' | 'transforms.conf' | 'raw';
+
 export interface ValidationDiagnostic {
   level: DiagnosticLevel;
   message: string;
-  file: 'props.conf' | 'transforms.conf';
+  file: DiagnosticTarget;
   line?: number;
   column?: number;
   directiveKey?: string;

--- a/src/monaco/splunkConfCompletion.ts
+++ b/src/monaco/splunkConfCompletion.ts
@@ -1,5 +1,5 @@
 import type { languages, editor, Position, CancellationToken } from 'monaco-editor';
-import { getDirectivesForFile, getDirectivesByCategory, type DirectiveInfo } from './directiveRegistry';
+import { getDirectivesForFile, getDirectivesByCategory, type DirectiveInfo } from '../engine/directiveRegistry';
 
 // Monaco CompletionItemKind numeric values (monaco-editor doesn't export the enum at runtime
 // when imported as `type`, so we maintain this local mapping for readability).

--- a/src/monaco/splunkConfDiagnostics.ts
+++ b/src/monaco/splunkConfDiagnostics.ts
@@ -1,5 +1,5 @@
 import type { editor } from 'monaco-editor';
-import { getDirectiveInfo, getClassBasedDirectiveBase } from './directiveRegistry';
+import { getDirectiveInfo, getClassBasedDirectiveBase } from '../engine/directiveRegistry';
 import { validateRegex } from '../utils/splunkRegex';
 
 export interface DiagnosticMarker {

--- a/src/monaco/splunkConfHover.ts
+++ b/src/monaco/splunkConfHover.ts
@@ -1,5 +1,5 @@
 import type { languages, editor, Position, CancellationToken } from 'monaco-editor';
-import { getDirectiveInfo, getClassBasedDirectiveBase } from './directiveRegistry';
+import { getDirectiveInfo, getClassBasedDirectiveBase } from '../engine/directiveRegistry';
 
 export function createHoverProvider(fileType: 'props.conf' | 'transforms.conf'): languages.HoverProvider {
   return {
@@ -60,7 +60,7 @@ export function createHoverProvider(fileType: 'props.conf' | 'transforms.conf'):
   };
 }
 
-function formatDirectiveHover(info: import('./directiveRegistry').DirectiveInfo, actualKey: string): string {
+function formatDirectiveHover(info: import('../engine/directiveRegistry').DirectiveInfo, actualKey: string): string {
   const parts: string[] = [];
 
   parts.push(`### ${actualKey}`);


### PR DESCRIPTION
KV_MODE=json previously scavenged a deeply-nested object (e.g. an inner `alert` block) when the whole event failed to parse, flattening it without its path prefix — inventing bare field names like `action` that Splunk never produces (it should be `event.alert.action`) and silently dropping every sibling/parent field. This is what made AWS Network Firewall events appear to extract only six fields.

Engine:
- extractJson now only recovers the outermost embedded object (keeps the legit "JSON wrapped in surrounding text" case) and never descends into nested fragments. When data looks like JSON but won't parse, it surfaces a warning instead of fabricating fields.
- parseWholeJson distinguishes "not JSON" from "malformed JSON".
- The malformed-JSON warning targets the new 'raw' diagnostic panel with the offending input line, not props.conf.
- confParser warns on case-mismatched attribute names (e.g. `kv_mode` -> `KV_MODE`); Splunk attribute names are case-sensitive so the mis-cased form is silently ignored and the default applies.

UI:
- Field sidebar (buildFieldTree) synthesizes intermediate container nodes so `event.alert.*` nests under real `event` / `event.alert` group headers instead of collapsing into depth-indented roots under an unrelated field.
- RawPanel renders a validation strip and registers its editor so raw-data diagnostics can navigate to the bad line.

Dedup:
- Moved directiveRegistry.ts into the engine (pure domain data) so both the conf parser and the Monaco tooling share one source of truth; added getCanonicalDirectiveKey for case-insensitive lookups.

Diagnostics shortened to one line + a suggestion to save screen space.