### PR TITLE
flattenJson: fix corruption of fields named after Object.prototype me…

### DIFF
--- a/src/engine/__tests__/indexedExtractions.test.ts
+++ b/src/engine/__tests__/indexedExtractions.test.ts
@@ -44,6 +44,24 @@ describe('applyIndexedExtractions — JSON', () => {
     expect(events[0].fields).toEqual({});
   });
 
+  it('extracts a key named after a prototype member instead of mangling it', () => {
+    const events = applyIndexedExtractions([event('{"toString":"v"}')], [dir('json')]);
+    expect(events[0].fields['toString']).toBe('v');
+  });
+
+  it('guards reserved keys after leading-underscore stripping', () => {
+    // INDEXED_EXTRACTIONS strips leading underscores, so `_constructor` would
+    // become `constructor`; the reserved-key guard must run after stripping.
+    const events = applyIndexedExtractions(
+      [event('{"_constructor":"bad","keep":"ok"}')],
+      [dir('json')]
+    );
+    // Reading `fields['constructor']` would return the inherited Object constructor,
+    // so assert the guard prevented an *own* property from being written.
+    expect(Object.prototype.hasOwnProperty.call(events[0].fields, 'constructor')).toBe(false);
+    expect(events[0].fields['keep']).toBe('ok');
+  });
+
   it('names array-of-object fields with {} multivalue notation (not positional)', () => {
     const events = applyIndexedExtractions(
       [event('{"items":[{"id":1,"n":"a"},{"id":2,"n":"b"}]}')],

--- a/src/engine/__tests__/kvMode.test.ts
+++ b/src/engine/__tests__/kvMode.test.ts
@@ -48,6 +48,25 @@ describe('applyKvMode — json', () => {
     expect(r.fields['{}']).toEqual(['1', '2', '3']);
   });
 
+  it('extracts keys named after Object.prototype members without corruption', () => {
+    // `fields` is a plain object that inherits Object.prototype, so a naive
+    // `fields[name] === undefined` check would read back the inherited function
+    // for keys like `toString`/`valueOf`, mangle the value into a multivalue,
+    // and silently drop the field from the extracted list.
+    const [r] = applyKvMode(
+      [event('{"toString":"x","valueOf":"y","hasOwnProperty":"z"}')],
+      [dir('json')],
+    );
+    expect(r.fields['toString']).toBe('x');
+    expect(r.fields['valueOf']).toBe('y');
+    expect(r.fields['hasOwnProperty']).toBe('z');
+  });
+
+  it('still promotes genuinely repeated prototype-named keys to multivalue', () => {
+    const [r] = applyKvMode([event('{"items":[{"toString":"a"},{"toString":"b"}]}')], [dir('json')]);
+    expect(r.fields['items{}.toString']).toEqual(['a', 'b']);
+  });
+
   it('does NOT scavenge bare leaf fields from a nested object when the outer JSON is malformed', () => {
     // The whole event fails JSON.parse (`<ID>` is not a valid token), but the nested
     // `alert` object is locally well-formed. The old behaviour flattened that inner

--- a/src/engine/utils/flattenJson.ts
+++ b/src/engine/utils/flattenJson.ts
@@ -1,5 +1,10 @@
 const MAX_DEPTH = 10;
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
+/** Keys reserved by Splunk / unsafe to use as field names. Checked after underscore stripping. */
+const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Flattens parsed JSON into Splunk-style dot/brace notation fields, matching
  * how Splunk's `spath` / `KV_MODE=json` / `INDEXED_EXTRACTIONS=json` name fields:
@@ -37,11 +42,17 @@ function addValue(
   name: string,
   value: string,
 ): void {
-  const existing = fields[name];
-  if (existing === undefined) {
+  // Use hasOwnProperty rather than `fields[name] === undefined`: a plain-object
+  // `fields` inherits Object.prototype members, so a JSON key like `toString` or
+  // `valueOf` would otherwise read back the inherited function instead of undefined
+  // and get wrongly promoted to a multivalue (and never recorded in `added`).
+  if (!hasOwn.call(fields, name)) {
     fields[name] = value;
     added.push(name);
-  } else if (Array.isArray(existing)) {
+    return;
+  }
+  const existing = fields[name];
+  if (Array.isArray(existing)) {
     existing.push(value);
   } else {
     fields[name] = [existing, value];
@@ -112,9 +123,11 @@ export function flattenJson(
   if (depth > MAX_DEPTH) return true;
 
   for (const [rawKey, value] of Object.entries(obj)) {
-    if (rawKey === '__proto__' || rawKey === 'constructor' || rawKey === 'prototype') continue;
     const key = options.stripLeadingUnderscore ? rawKey.replace(/^_+/, '') : rawKey;
     if (!key) continue;
+    // Guard after stripping: with stripLeadingUnderscore a key like `_constructor`
+    // becomes `constructor`, so checking the raw key alone would let it through.
+    if (RESERVED_KEYS.has(key)) continue;
     const fieldName = prefix ? `${prefix}.${key}` : key;
 
     if (options.sourceKeys && key !== rawKey) {


### PR DESCRIPTION
(#20)

`addValue` checked field existence with `fields[name] === undefined` against a plain object, so any JSON key colliding with an inherited Object.prototype member (`toString`, `valueOf`, `hasOwnProperty`, …) read back the inherited function instead of undefined. Such fields were wrongly promoted to a multivalue and never recorded in `added`, so downstream tabs/CIM matching dropped them.

Switch the existence check to `Object.prototype.hasOwnProperty.call`. Also move the reserved-key guard (`__proto__`/`constructor`/`prototype`) to run after leading- underscore stripping, so a key like `_constructor` (which INDEXED_EXTRACTIONS strips to `constructor`) is still guarded rather than slipping through.

Adds tests in kvMode and indexedExtractions covering both defects.