### PR TITLE
eval: fix mvzip/mvcount NULL semantics and implement isbool/isstr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Splunk Toolkit are documented here, newest first.
 
 ---
 
+## 2026-07-01
+
+### Fixed
+
+- **eval `mvzip` padded to the longer field instead of stopping at the shorter** — it now behaves like a true zip, producing only as many values as the shorter field. `mvzip(["a","b","c"], ["1","2"])` → `["a,1","b,2"]` (previously `["a,1","b,2","c,"]`). ([src/engine/processors/evalProcessor.ts](src/engine/processors/evalProcessor.ts))
+- **eval `mvcount` returned `0` for a field with no values** — Splunk returns NULL (a single value → 1, multiple → count, no values → NULL). `mvcount` now returns NULL when the field is empty/missing.
+
+### Added
+
+- **eval `isbool()` and `isstr()`** — previously unimplemented (they fell through to the stub default and silently returned null). They now report the value's actual type, mirroring `typeof`'s type model. Both are registered in the Monaco eval-function list. ([src/engine/processors/evalProcessor.ts](src/engine/processors/evalProcessor.ts))
+
+---
+
 ## 2026-05-31
 
 ### Added

--- a/src/components/editor/splunkMonacoSetup.ts
+++ b/src/components/editor/splunkMonacoSetup.ts
@@ -64,7 +64,7 @@ function registerSplunkConfLanguage(monaco: MonacoApi) {
       'if', 'case', 'coalesce', 'nullif', 'validate',
       'lower', 'upper', 'len', 'substr', 'replace', 'trim', 'ltrim', 'rtrim',
       'urldecode', 'split', 'mvjoin', 'tonumber', 'tostring', 'typeof',
-      'isnull', 'isnotnull', 'isint', 'isnum',
+      'isnull', 'isnotnull', 'isint', 'isnum', 'isbool', 'isstr',
       'abs', 'ceiling', 'ceil', 'floor', 'round', 'sqrt', 'pow',
       'log', 'ln', 'exp', 'pi', 'min', 'max', 'random',
       'mvcount', 'mvindex', 'mvfilter', 'mvappend', 'mvdedup', 'mvfind', 'mvsort', 'mvzip',

--- a/src/engine/__tests__/evalProcessor.test.ts
+++ b/src/engine/__tests__/evalProcessor.test.ts
@@ -145,6 +145,34 @@ describe('applyEvalExpressions — function fidelity', () => {
     expect(oor.fields['x']).toBeUndefined(); // null → field deleted
   });
 
+  it('mvzip stops at the shorter field (no padding)', () => {
+    const [r] = applyEvalExpressions(
+      [event({})],
+      [evalDir('z', 'mvjoin(mvzip(split("a,b,c", ","), split("1,2", ",")), "|")')],
+    );
+    expect(r.fields['z']).toBe('a,1|b,2');
+  });
+
+  it('mvcount returns NULL for no values and 1 for a single value', () => {
+    // No values → null → field not set.
+    const [none] = applyEvalExpressions([event({})], [evalDir('c', 'mvcount(missing)')]);
+    expect(none.fields['c']).toBeUndefined();
+    // Single value → 1.
+    const [one] = applyEvalExpressions([event({ a: 'x' })], [evalDir('c', 'mvcount(a)')]);
+    expect(one.fields['c']).toBe('1');
+    // Multivalue → count.
+    const [many] = applyEvalExpressions([event({})], [evalDir('c', 'mvcount(split("a,b,c", ","))')]);
+    expect(many.fields['c']).toBe('3');
+  });
+
+  it('isbool and isstr report the value type like typeof', () => {
+    const [r] = applyEvalExpressions(
+      [event({ a: 'hi' })],
+      [evalDir('t', 'isstr(a) . "," . isstr(1==1) . "," . isbool(1==1) . "," . isbool("x")')],
+    );
+    expect(r.fields['t']).toBe('true,false,true,false');
+  });
+
   it('max() treats strings as greater than numbers; min() picks the number', () => {
     const [mx] = applyEvalExpressions([event({})], [evalDir('m', 'max(5, "apple", 10)')]);
     expect(mx.fields['m']).toBe('apple');

--- a/src/engine/processors/evalProcessor.ts
+++ b/src/engine/processors/evalProcessor.ts
@@ -659,6 +659,10 @@ function evalBuiltin(fn: string, args: EvalValue[], ctx: EvalCtx): EvalValue {
     case 'isnotnull': return args[0] !== null && args[0] !== undefined;
     case 'isint': return isNumericValue(args[0]) && Number.isInteger(Number(args[0]));
     case 'isnum': return isNumericValue(args[0]);
+    // Informational functions mirror `typeof`'s type model: they report the
+    // value's actual type rather than what it could be coerced to.
+    case 'isbool': return typeof args[0] === 'boolean';
+    case 'isstr': return typeof args[0] === 'string';
 
     // Math
     case 'abs': return Math.abs(toNum(args[0]));
@@ -689,7 +693,11 @@ function evalBuiltin(fn: string, args: EvalValue[], ctx: EvalCtx): EvalValue {
     case 'sigfig': return toNum(args[0]);
 
     // Multivalue
-    case 'mvcount': return toMv(args[0]).length;
+    case 'mvcount': {
+      // Splunk: a single value → 1, multiple → count, no values → NULL (not 0).
+      const m = toMv(args[0]);
+      return m.length === 0 ? null : m.length;
+    }
     case 'mvindex': {
       const mv = toMv(args[0]);
       const n = mv.length;
@@ -718,10 +726,12 @@ function evalBuiltin(fn: string, args: EvalValue[], ctx: EvalCtx): EvalValue {
       const a = toMv(args[0]);
       const b = toMv(args[1]);
       const delim = args[2] !== undefined ? toStr(args[2]) : ',';
-      const len = Math.max(a.length, b.length);
+      // Splunk mvzip behaves like a zip: it stops at the shorter field rather
+      // than padding out to the longer one.
+      const len = Math.min(a.length, b.length);
       const result: string[] = [];
       for (let i = 0; i < len; i++) {
-        result.push((a[i] ?? '') + delim + (b[i] ?? ''));
+        result.push(a[i] + delim + b[i]);
       }
       return result;
     }


### PR DESCRIPTION
Fixes #38.

Addresses the three confirmed correctness gaps from the eval-function audit against Splunk's documentation.

## Changes

**1. `mvzip` now stops at the shorter field**
It previously padded out to the longer field (`Math.max` + `''` padding). Splunk's `mvzip` behaves like a zip and only produces as many values as the shorter field. Switched to `Math.min` and dropped the padding.
- `mvzip(["a","b","c"], ["1","2"])` → `["a,1","b,2"]` (was `["a,1","b,2","c,"]`)

**2. `mvcount` returns NULL for a field with no values**
It previously returned `0`. Splunk returns NULL when there are no values (single value → 1, multiple → count, no values → NULL). A null result means the field is simply not set.

**3. `isbool()` and `isstr()` implemented**
Both were unimplemented and fell through to the stub `default` (warn + return null), so any expression using them silently yielded null. They now report the value's actual type, mirroring the existing `typeof` type model. Both are also registered in the Monaco eval-function list for editor highlighting/autocomplete.

The two "suspected" edge cases in the issue (`tonumber("-10", 16)`, `isint("3.0")`) are left untouched pending verification against real Splunk, per the issue's own guidance.

## Testing

- Added unit tests for all three fixes in `evalProcessor.test.ts`.
- Full suite: **321 tests pass** (28 files).
- `npm run lint` clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqXLXbu5Dz4GUGprKvvuiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqXLXbu5Dz4GUGprKvvuiB)_