### PR TITLE
sed: unescape escaped delimiters/literals in the replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Splunk Toolkit are documented here, newest first.
 
 ### Fixed
 
+- **`SEDCMD` left a stray backslash when a delimiter was escaped in the replacement** — `s/b/x\/y/` produced `ax\/yc` instead of GNU sed's `ax/yc`. The parser preserves backslashes verbatim, but the replacement builder never unescaped them. Replacement construction is now a single left-to-right pass that resolves sed escapes correctly: `\1`–`\9` stay backreferences, any other `\<char>` (an escaped delimiter, `\\` → `\`, etc.) drops the backslash, and a bare `$` is still escaped so JS doesn't read it as a substitution pattern. This also fixes `\\1` being mis-read as capture-group 1 rather than a literal `\1`. ([src/engine/processors/sedCmd.ts](src/engine/processors/sedCmd.ts))
 - **eval `mvzip` padded to the longer field instead of stopping at the shorter** — it now behaves like a true zip, producing only as many values as the shorter field. `mvzip(["a","b","c"], ["1","2"])` → `["a,1","b,2"]` (previously `["a,1","b,2","c,"]`). ([src/engine/processors/evalProcessor.ts](src/engine/processors/evalProcessor.ts))
 - **eval `mvcount` returned `0` for a field with no values** — Splunk returns NULL (a single value → 1, multiple → count, no values → NULL). `mvcount` now returns NULL when the field is empty/missing.
 

--- a/src/engine/__tests__/sedCmd.test.ts
+++ b/src/engine/__tests__/sedCmd.test.ts
@@ -41,6 +41,25 @@ describe('applySedCommands', () => {
     expect(e._raw).toBe('$5.00');
   });
 
+  // #21: an escaped delimiter in the replacement drops the backslash (GNU sed:
+  // `echo abc | sed 's/b/x\/y/'` → `ax/yc`), rather than leaving a stray `\`.
+  it('unescapes an escaped delimiter in the replacement', () => {
+    const [e] = applySedCommands([event('abc')], [sedDir('x', 's/b/x\\/y/')]);
+    expect(e._raw).toBe('ax/yc');
+  });
+
+  it('unescapes a doubled backslash to a single backslash', () => {
+    const [e] = applySedCommands([event('a')], [sedDir('x', 's/a/x\\\\y/')]);
+    expect(e._raw).toBe('x\\y');
+  });
+
+  // A backslash-escaped backslash before a digit is a literal backslash, not a
+  // backreference: `\\1` → literal `\1`, never capture group 1.
+  it('does not treat an escaped backslash before a digit as a backreference', () => {
+    const [e] = applySedCommands([event('foo')], [sedDir('x', 's/(o)/\\\\1/g')]);
+    expect(e._raw).toBe('f\\1\\1');
+  });
+
   it('applies multiple SEDCMD classes in ASCII order', () => {
     // class "a" runs before class "b": a turns X→Y, then b turns Y→Z.
     const [e] = applySedCommands([event('X')], [sedDir('b', 's/Y/Z/'), sedDir('a', 's/X/Y/')]);

--- a/src/engine/processors/sedCmd.ts
+++ b/src/engine/processors/sedCmd.ts
@@ -9,6 +9,33 @@ interface SedCommand {
   global: boolean;
 }
 
+/**
+ * Turn a parsed sed replacement string into a JS `String.replace` replacement.
+ * The parser preserves backslashes verbatim, so this single left-to-right pass
+ * resolves the escapes with sed's semantics:
+ *   - `\1`..`\9`  → capture-group backreferences (`$1`..`$9`)
+ *   - `\<char>`   → the escaped literal, with the backslash dropped (this covers
+ *                   an escaped delimiter like `s/b/x\/y/` → `x/y`, plus `\\` → `\`)
+ *   - a bare `$`  → escaped to `$$` so JS doesn't read it as a substitution
+ *                   pattern (sed treats `$` as an ordinary character)
+ */
+function buildReplacement(raw: string): string {
+  let out = '';
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (c === '\\' && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      // \0..\9 stay backreferences (mirrors the previous \\(\d) → $n behaviour);
+      // any other escaped character becomes the bare literal.
+      out += next >= '0' && next <= '9' ? '$' + next : next === '$' ? '$$' : next;
+      i++;
+      continue;
+    }
+    out += c === '$' ? '$$' : c;
+  }
+  return out;
+}
+
 function parseSedExpression(
   value: string,
   dir?: ConfDirective,
@@ -61,14 +88,7 @@ function parseSedExpression(
   if (parts.length < 2) return null;
 
   const patternStr = parts[0];
-  // Convert sed/Splunk backreferences (\1..\9) to JS replacement syntax ($1..$9).
-  // First escape any literal `$` to `$$` — in sed `$` is a literal character, but
-  // JS String.replace treats `$1`/`$&` as substitution patterns, so an un-escaped
-  // `$` (e.g. s/price/$5.00/) would mangle the output. Escape before introducing
-  // our own `$n` backrefs so they survive.
-  const replacement = (parts[1] ?? '')
-    .replace(/\$/g, '$$$$')
-    .replace(/\\(\d)/g, '$$$1');
+  const replacement = buildReplacement(parts[1] ?? '');
   const flags = parts[2] ?? '';
   const isGlobal = flags.includes('g');
 


### PR DESCRIPTION
Fixes #21.

## Problem
`SEDCMD` parsing preserves backslashes verbatim through the parse loop, but the replacement builder only rewrote `\1`–`\9` and escaped a literal `$`. It never removed the backslash that escapes a delimiter, so an escaped delimiter leaked into the output:

- Config: `SEDCMD-x = s/b/x\/y/`, input `abc`
- Produced: `ax\/yc`
- Expected (GNU sed `echo abc | sed 's/b/x\/y/'`): `ax/yc`

## Fix
Replaced the two-pass regex substitution with a single left-to-right scan (`buildReplacement`) that resolves sed replacement escapes correctly:

- `\0`–`\9` → capture-group backreferences (`$0`–`$9`), preserving prior behaviour
- any other `\<char>` → the bare literal, backslash dropped (covers the escaped delimiter and `\\` → `\`)
- a bare `$` → escaped to `$$` so `String.replace` doesn't read it as a substitution pattern (sed treats `$` as ordinary)

As a bonus this fixes a latent bug where `\\1` (an escaped backslash before a digit) was mis-read by the old `\\(\d)` regex as capture-group 1 instead of a literal `\1`.

## Testing
- Added tests for the escaped delimiter, a doubled backslash (`\\` → `\`), and the `\\1`-is-literal case.
- Existing backreference and literal-`$` tests still pass unchanged.
- Full suite: **324 tests pass** (28 files). `npm run lint` clean, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqXLXbu5Dz4GUGprKvvuiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqXLXbu5Dz4GUGprKvvuiB)_