### PR TITLE
strftime: close five TIME_FORMAT/strptime fidelity gaps (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Splunk Toolkit are documented here, newest first.
 
 ---
 
+## 2026-07-04
+
+### Fixed
+
+- **Five TIME_FORMAT/strptime fidelity gaps meant common Splunk-documented formats silently produced no `_time`** — an unknown directive falls through to *literal* matching, so a single unsupported specifier makes the whole format fail with no diagnostic. `parseTimestamp`/`strftimeToRegex` now: (1) support the enhanced-strptime offset forms `%:z`/`%::z` (colon-separated), bare `%N` (= `%9N`) and the `%Q`/`%3Q`/`%6Q`/`%9Q` subsecond family (bare `%Q` = `%3Q`); (2) fold captured subseconds into an epoch timestamp instead of returning early and discarding them, so the documented `TIME_FORMAT = %s%3N` keeps its milliseconds; (3) accept 1–2 unpadded digits for `%m %d %H %I %M %S` (POSIX/glibc strptime), so US-style `1/5/2024 3:04:05` parses; (4) use the POSIX `%y` century pivot (69–99 → 1969–1999, 00–68 → 2000–2068) instead of an off-by-one at 69; and (5) expand the `%T`/`%F` composites with a `%%`-aware scan, so `%%T` stays a literal `%T` rather than corrupting into `%%H:%M:%S`. ([src/utils/strftime.ts](src/utils/strftime.ts))
+
+---
+
 ## 2026-07-01
 
 ### Changed

--- a/src/utils/__tests__/strftime.test.ts
+++ b/src/utils/__tests__/strftime.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { parseTimestamp, strftimeToRegex } from '../strftime';
+
+/** Helper: ISO string of a parsed timestamp, or null. */
+function iso(text: string, format: string, tz?: string): string | null {
+  const d = parseTimestamp(text, format, tz);
+  return d ? d.toISOString() : null;
+}
+
+describe('strftime — baseline directives (regression)', () => {
+  it('parses a full ISO-8601 timestamp with milliseconds', () => {
+    expect(iso('2024-01-15T10:00:00.123', '%Y-%m-%dT%H:%M:%S.%3N'))
+      .toBe('2024-01-15T10:00:00.123Z');
+  });
+
+  it('parses month abbreviations', () => {
+    expect(iso('Jan 15 2024 10:00:00', '%b %d %Y %H:%M:%S'))
+      .toBe('2024-01-15T10:00:00.000Z');
+  });
+
+  it('applies a numeric %z offset', () => {
+    expect(iso('2024-01-15T10:00:00+05:30', '%Y-%m-%dT%H:%M:%S%z'))
+      .toBe('2024-01-15T04:30:00.000Z');
+  });
+
+  it('rejects out-of-range components', () => {
+    expect(parseTimestamp('2024-13-15 10:00:00', '%Y-%m-%d %H:%M:%S')).toBeNull();
+    expect(parseTimestamp('2024-01-32 10:00:00', '%Y-%m-%d %H:%M:%S')).toBeNull();
+  });
+
+  it('expands the %T and %F composites', () => {
+    expect(iso('2024-01-15 10:00:00', '%F %T')).toBe('2024-01-15T10:00:00.000Z');
+  });
+});
+
+describe('#69.1 — Splunk enhanced-strptime specifiers', () => {
+  it('supports %:z (offset with a colon)', () => {
+    expect(iso('2024-01-02T03:04:05+05:30', '%Y-%m-%dT%H:%M:%S%:z'))
+      .toBe('2024-01-01T21:34:05.000Z');
+  });
+
+  it('supports %::z (offset with seconds)', () => {
+    expect(iso('2024-01-02T03:04:05+05:30:00', '%Y-%m-%dT%H:%M:%S%::z'))
+      .toBe('2024-01-01T21:34:05.000Z');
+  });
+
+  it('supports bare %N as %9N (nanoseconds)', () => {
+    expect(iso('2024-01-15T10:00:00.123456789', '%Y-%m-%dT%H:%M:%S.%N'))
+      .toBe('2024-01-15T10:00:00.123Z');
+  });
+
+  it('supports the %Q subsecond family with %s', () => {
+    // 1712345678 seconds + 123 ms
+    expect(parseTimestamp('1712345678123', '%s%3Q')?.getTime()).toBe(1712345678123);
+    // bare %Q == %3Q
+    expect(parseTimestamp('1712345678123', '%s%Q')?.getTime()).toBe(1712345678123);
+  });
+});
+
+describe('#69.2 — %s must not discard captured subseconds', () => {
+  it('folds %3N milliseconds into an epoch-seconds timestamp', () => {
+    expect(parseTimestamp('1712345678123', '%s%3N')?.getTime()).toBe(1712345678123);
+  });
+
+  it('folds %6N microseconds (floored to ms) into %s', () => {
+    // 1712345678 s + 456789 us -> +456 ms
+    expect(parseTimestamp('1712345678456789', '%s%6N')?.getTime()).toBe(1712345678456);
+  });
+});
+
+describe('#69.3 — numeric directives accept 1-2 unpadded digits', () => {
+  it('parses US-style unpadded dates and times', () => {
+    expect(iso('1/5/2024 3:04:05', '%m/%d/%Y %H:%M:%S'))
+      .toBe('2024-01-05T03:04:05.000Z');
+  });
+
+  it('still parses zero-padded values', () => {
+    expect(iso('01/05/2024 03:04:05', '%m/%d/%Y %H:%M:%S'))
+      .toBe('2024-01-05T03:04:05.000Z');
+  });
+});
+
+describe('#69.4 — %y century pivot (POSIX)', () => {
+  it('maps 69 to 1969', () => {
+    expect(iso('69-01-02', '%y-%m-%d')).toBe('1969-01-02T00:00:00.000Z');
+  });
+
+  it('maps 68 to 2068', () => {
+    expect(iso('68-01-02', '%y-%m-%d')).toBe('2068-01-02T00:00:00.000Z');
+  });
+
+  it('maps 70 to 1970', () => {
+    expect(iso('70-01-02', '%y-%m-%d')).toBe('1970-01-02T00:00:00.000Z');
+  });
+});
+
+describe('#69.5 — %%T must not corrupt into %H handling', () => {
+  it('treats %%T as a literal percent followed by T', () => {
+    expect(strftimeToRegex('%%T').source).toBe('%T');
+  });
+
+  it('matches a literal "%T" in the text', () => {
+    expect(iso('2024-01-15%T', '%Y-%m-%d%%T')).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('still expands a standalone %T', () => {
+    expect(strftimeToRegex('%T').source).toBe('(\\d{1,2}):(\\d{1,2}):(\\d{1,2})');
+  });
+});

--- a/src/utils/strftime.ts
+++ b/src/utils/strftime.ts
@@ -45,13 +45,15 @@ function buildDirectiveMap(): Record<string, DirectiveMeta> {
   return {
     '%Y': { regex: '(\\d{4})', capture: 'year4' },
     '%y': { regex: '(\\d{2})', capture: 'year2' },
-    '%m': { regex: '(\\d{2})', capture: 'month' },
-    '%d': { regex: '(\\d{2})', capture: 'day' },
+    // POSIX/glibc strptime (which Splunk uses) accepts 1-2 digits for these
+    // numeric fields, so unpadded values like `1/5/2024 3:04:05` still parse.
+    '%m': { regex: '(\\d{1,2})', capture: 'month' },
+    '%d': { regex: '(\\d{1,2})', capture: 'day' },
     '%e': { regex: '(\\s?\\d{1,2})', capture: 'day' },
-    '%H': { regex: '(\\d{2})', capture: 'hour24' },
-    '%I': { regex: '(\\d{2})', capture: 'hour12' },
-    '%M': { regex: '(\\d{2})', capture: 'minute' },
-    '%S': { regex: '(\\d{2})', capture: 'second' },
+    '%H': { regex: '(\\d{1,2})', capture: 'hour24' },
+    '%I': { regex: '(\\d{1,2})', capture: 'hour12' },
+    '%M': { regex: '(\\d{1,2})', capture: 'minute' },
+    '%S': { regex: '(\\d{1,2})', capture: 'second' },
     '%p': { regex: '([AaPp][Mm])', capture: 'ampm' },
     '%b': { regex: `(${MONTH_NAMES_ABBR.join('|')})`, capture: 'monthAbbr' },
     '%B': { regex: `(${MONTH_NAMES_FULL.join('|')})`, capture: 'monthFull' },
@@ -60,10 +62,20 @@ function buildDirectiveMap(): Record<string, DirectiveMeta> {
     '%Z': { regex: '([A-Za-z][A-Za-z0-9_/+-]*)', capture: 'tzName' },
     // ISO-8601 'Z' (Zulu/UTC), ±HH:MM / ±HHMM, and ±HH-only offsets.
     '%z': { regex: '(Z|[+-]\\d{2}:?\\d{2}|[+-]\\d{2})', capture: 'tzOffset' },
+    // Splunk "enhanced strptime" offsets with explicit colons.
+    '%:z': { regex: '(Z|[+-]\\d{2}:\\d{2})', capture: 'tzOffset' },
+    '%::z': { regex: '(Z|[+-]\\d{2}:\\d{2}:\\d{2})', capture: 'tzOffset' },
     '%s': { regex: '(\\d{10,13})', capture: 'epoch' },
     '%3N': { regex: '(\\d{3})', capture: 'milliseconds' },
     '%6N': { regex: '(\\d{6})', capture: 'microseconds' },
     '%9N': { regex: '(\\d{9})', capture: 'nanoseconds' },
+    // Bare %N is Splunk shorthand for %9N (nanoseconds).
+    '%N': { regex: '(\\d{9})', capture: 'nanoseconds' },
+    // %Q family: subsecond digits, bare %Q == %3Q (milliseconds).
+    '%Q': { regex: '(\\d{3})', capture: 'milliseconds' },
+    '%3Q': { regex: '(\\d{3})', capture: 'milliseconds' },
+    '%6Q': { regex: '(\\d{6})', capture: 'microseconds' },
+    '%9Q': { regex: '(\\d{9})', capture: 'nanoseconds' },
     // Additional specifiers
     '%f': { regex: '(\\d{1,6})', capture: 'microsecondsFull' },
     '%j': { regex: '(\\d{3})', capture: 'dayOfYear' },
@@ -82,11 +94,36 @@ const DIRECTIVE_MAP = buildDirectiveMap();
 // Expand composite directives so the main loop only deals with atomic ones.
 // ---------------------------------------------------------------------------
 function expandComposites(format: string): string {
-  let result = format;
-  // Keep expanding until no composites remain (safe against double-expansion
-  // because the replacements don't re-introduce %T or %F).
-  result = result.replace(/%T/g, '%H:%M:%S');
-  result = result.replace(/%F/g, '%Y-%m-%d');
+  // Walk the string so a `%%` escape consumes both percent signs before we
+  // look for a composite: `%%T` must stay a literal `%T`, not expand the inner
+  // `%T` into `%%H:%M:%S`.
+  let result = '';
+  let i = 0;
+  while (i < format.length) {
+    if (format[i] === '%') {
+      const two = format.slice(i, i + 2);
+      if (two === '%%') {
+        result += '%%';
+        i += 2;
+        continue;
+      }
+      if (two === '%T') {
+        result += '%H:%M:%S';
+        i += 2;
+        continue;
+      }
+      if (two === '%F') {
+        result += '%Y-%m-%d';
+        i += 2;
+        continue;
+      }
+      result += format[i];
+      i += 1;
+      continue;
+    }
+    result += format[i];
+    i += 1;
+  }
   return result;
 }
 
@@ -108,12 +145,22 @@ function tokenise(format: string): TokenisedFormat {
 
   while (i < expanded.length) {
     if (expanded[i] === '%') {
-      // Try multi-character directives first (%3N, %6N, %9N)
+      // Try the longest directives first so `%::z` wins over `%:z`, and
+      // `%3N`/`%3Q` win over a bare `%` literal. Longest → shortest.
+      const fourChar = expanded.slice(i, i + 4);
+      const fourMeta = DIRECTIVE_MAP[fourChar];
+      if (fourMeta) {
+        regexStr += fourMeta.regex;
+        captures.push(fourMeta.capture);
+        i += 4;
+        continue;
+      }
+
       const threeChar = expanded.slice(i, i + 3);
-      if (threeChar === '%3N' || threeChar === '%6N' || threeChar === '%9N') {
-        const meta = DIRECTIVE_MAP[threeChar];
-        regexStr += meta.regex;
-        captures.push(meta.capture);
+      const threeMeta = DIRECTIVE_MAP[threeChar];
+      if (threeMeta) {
+        regexStr += threeMeta.regex;
+        captures.push(threeMeta.capture);
         i += 3;
         continue;
       }
@@ -206,14 +253,42 @@ function resolveTzOffsetMinutes(tz: string): number | null {
     return TZ_OFFSETS[upper];
   }
 
-  // Try parsing as +HHMM / -HH:MM / +HH (minutes optional).
-  const m = /^([+-])(\d{2})(?::?(\d{2}))?$/.exec(tz);
+  // Try parsing as +HHMM / -HH:MM / +HH:MM:SS / +HH (minutes and seconds
+  // optional, colons optional) — covers %z, %:z and %::z outputs.
+  const m = /^([+-])(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?$/.exec(tz);
   if (m) {
     const sign = m[1] === '+' ? 1 : -1;
-    return sign * (parseInt(m[2], 10) * 60 + (m[3] ? parseInt(m[3], 10) : 0));
+    const minutes = parseInt(m[2], 10) * 60
+      + (m[3] ? parseInt(m[3], 10) : 0)
+      + (m[4] ? parseInt(m[4], 10) / 60 : 0);
+    return sign * minutes;
   }
 
   return null;
+}
+
+/**
+ * Convert captured subsecond digits into whole milliseconds.
+ *
+ * Handles %3N/%6N/%9N and the %Q family (which share the milliseconds/
+ * microseconds/nanoseconds captures) plus %f. Returns 0 when none are present.
+ */
+function computeSubMilliseconds(bag: Record<string, string>): number {
+  if (bag.milliseconds) {
+    return parseInt(bag.milliseconds, 10);
+  }
+  if (bag.microseconds) {
+    return Math.floor(parseInt(bag.microseconds, 10) / 1000);
+  }
+  if (bag.microsecondsFull) {
+    // %f: 1-6 digit microseconds — pad to 6 digits then convert to ms.
+    const padded = bag.microsecondsFull.padEnd(6, '0');
+    return Math.floor(parseInt(padded, 10) / 1000);
+  }
+  if (bag.nanoseconds) {
+    return Math.floor(parseInt(bag.nanoseconds, 10) / 1_000_000);
+  }
+  return 0;
 }
 
 /**
@@ -250,16 +325,22 @@ export function parseTimestamp(
     }
   }
 
+  // Subsecond digits captured by %3N/%6N/%9N, the %Q family, or %f, converted
+  // to whole milliseconds. Shared by the epoch and calendar paths.
+  const subMilliseconds = computeSubMilliseconds(bag);
+
   // -----------------------------------------------------------------------
   // Handle epoch seconds / milliseconds directly
   // -----------------------------------------------------------------------
   if (bag.epoch) {
     const epochNum = parseInt(bag.epoch, 10);
-    // If the value is 13 digits it is already milliseconds.
+    // If the value is 13 digits it is already milliseconds; a captured
+    // subsecond field would be below ms resolution, so leave it as-is.
     if (bag.epoch.length >= 13) {
       return new Date(epochNum);
     }
-    return new Date(epochNum * 1000);
+    // Seconds since epoch: fold in any subseconds from e.g. `%s%3N`/`%s%3Q`.
+    return new Date(epochNum * 1000 + subMilliseconds);
   }
 
   // -----------------------------------------------------------------------
@@ -270,7 +351,8 @@ export function parseTimestamp(
     year = parseInt(bag.year4, 10);
   } else if (bag.year2) {
     const y2 = parseInt(bag.year2, 10);
-    year = y2 >= 70 ? 1900 + y2 : 2000 + y2;
+    // POSIX %y pivot: 69-99 → 1969-1999, 00-68 → 2000-2068.
+    year = y2 >= 69 ? 1900 + y2 : 2000 + y2;
   } else {
     // Default to current year when the format doesn't include a year.
     year = new Date().getFullYear();
@@ -343,18 +425,7 @@ export function parseTimestamp(
     return null;
   }
 
-  let milliseconds = 0;
-  if (bag.milliseconds) {
-    milliseconds = parseInt(bag.milliseconds, 10);
-  } else if (bag.microseconds) {
-    milliseconds = Math.floor(parseInt(bag.microseconds, 10) / 1000);
-  } else if (bag.microsecondsFull) {
-    // %f: 1-6 digit microseconds — pad to 6 digits then convert to ms
-    const padded = bag.microsecondsFull.padEnd(6, '0');
-    milliseconds = Math.floor(parseInt(padded, 10) / 1000);
-  } else if (bag.nanoseconds) {
-    milliseconds = Math.floor(parseInt(bag.nanoseconds, 10) / 1_000_000);
-  }
+  const milliseconds = subMilliseconds;
 
   // -----------------------------------------------------------------------
   // Resolve timezone offset


### PR DESCRIPTION
Fixes #69.

An unknown strftime directive falls through to *literal* matching, so one unsupported specifier makes the whole `TIME_FORMAT` fail and the event silently gets no `_time`, with no diagnostic. This closes the five documented gaps in `src/utils/strftime.ts`.

## Changes
1. **Enhanced-strptime specifiers** — `%:z` / `%::z` (colon-separated offsets), bare `%N` (= `%9N`), and the `%Q`/`%3Q`/`%6Q`/`%9Q` subsecond family (bare `%Q` = `%3Q`). The tokeniser now matches longest→shortest so `%::z` beats `%:z` and `%3Q` beats a bare `%`. `resolveTzOffsetMinutes` learned the `+HH:MM:SS` form.
2. **`%s` subseconds** — subsecond digits are now folded into an epoch timestamp instead of the early `return` discarding them, so the Splunk-recommended `TIME_FORMAT = %s%3N` keeps its milliseconds (`1712345678123` → `…678.123`).
3. **Unpadded numerics** — `%m %d %H %I %M %S` accept 1–2 digits (POSIX/glibc strptime), so US-style `1/5/2024 3:04:05` parses.
4. **`%y` pivot** — POSIX century pivot `69–99 → 1969–1999`, `00–68 → 2000–2068` (was off by one at 69).
5. **`%%T` corruption** — composite expansion is `%%`-aware, so `%%T` stays a literal `%T` instead of becoming `%%H:%M:%S`.

## Testing
- New `src/utils/__tests__/strftime.test.ts` — 19 cases, one group per gap plus baseline regressions.
- Full suite green locally: **404 tests pass**; `npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)